### PR TITLE
Fix triggers for terminatingpod sanity check

### DIFF
--- a/pkg/controller/actions.go
+++ b/pkg/controller/actions.go
@@ -27,14 +27,14 @@ func (c *Controller) clusterAction(ctx context.Context, admin redis.AdminInterfa
 	var err error
 	result := ctrl.Result{}
 	// run sanity check if needed
-	needSanity, err := sanitycheck.RunSanityChecks(ctx, admin, &c.config.redis, c.podControl, cluster, infos, true)
+	needSanity, sanitizeAction, err := sanitycheck.RunSanityChecks(ctx, admin, &c.config.redis, c.podControl, cluster, infos, true)
 	if err != nil {
-		glog.Errorf("[clusterAction] cluster %s/%s, an error occurs during sanity check: %v ", cluster.Namespace, cluster.Name, err)
+		glog.Errorf("[clusterAction] cluster %s/%s, an error occurs during sanity check %s: %v ", cluster.Namespace, cluster.Name, sanitizeAction, err)
 		return result, err
 	}
 	if needSanity {
-		glog.V(3).Infof("[clusterAction] run sanity check cluster: %s/%s", cluster.Namespace, cluster.Name)
-		result.Requeue, err = sanitycheck.RunSanityChecks(ctx, admin, &c.config.redis, c.podControl, cluster, infos, false)
+		glog.V(3).Infof("[clusterAction] run sanity check %s, cluster: %s/%s", sanitizeAction, cluster.Namespace, cluster.Name)
+		result.Requeue, sanitizeAction, err = sanitycheck.RunSanityChecks(ctx, admin, &c.config.redis, c.podControl, cluster, infos, false)
 		return result, err
 	}
 

--- a/pkg/controller/sanitycheck/process.go
+++ b/pkg/controller/sanitycheck/process.go
@@ -12,43 +12,60 @@ import (
 	"github.com/IBM/operator-for-redis-cluster/pkg/redis"
 )
 
+const (
+	NoAction                 = "NoAction"
+	FixFailedNodesAction     = "FixFailedNodesAction"
+	FixUntrustedNodesAction  = "FixUntrustedNodesAction"
+	FixTerminatingPodsAction = "FixTerminatingPodsAction"
+	FixClusterSplitAction    = "FixClusterSplitAction"
+)
+
 // RunSanityChecks function used to run all the sanity check on the current cluster
 // Return actionDone = true if a modification has been made on the cluster
-func RunSanityChecks(ctx context.Context, admin redis.AdminInterface, config *config.Redis, podControl pod.RedisClusterControlInterface, cluster *rapi.RedisCluster, infos *redis.ClusterInfos, dryRun bool) (actionDone bool, err error) {
+func RunSanityChecks(ctx context.Context, admin redis.AdminInterface, config *config.Redis, podControl pod.RedisClusterControlInterface, cluster *rapi.RedisCluster, infos *redis.ClusterInfos, dryRun bool) (actionDone bool, action string, err error) {
+	action = NoAction
 	if cluster.Status.Cluster.Status == rapi.ClusterStatusRollingUpdate {
-		return false, nil
+		return false, action, nil
 	}
+
 	// * fix failed nodes: in some cases (cluster without enough primary after crash or scale down), some nodes may still know about fail nodes
+	action = FixFailedNodesAction
 	if actionDone, err = FixFailedNodes(ctx, admin, cluster, infos, dryRun); err != nil {
-		return actionDone, err
+		return actionDone, action, err
 	} else if actionDone {
 		glog.V(2).Infof("FixFailedNodes executed an action on the cluster (dryRun: %v)", dryRun)
-		return actionDone, nil
+		return actionDone, action, nil
 	}
 
 	// forget nodes and delete pods when a redis node is untrusted.
+	action = FixUntrustedNodesAction
 	if actionDone, err = FixUntrustedNodes(ctx, admin, podControl, cluster, infos, dryRun); err != nil {
-		return actionDone, err
+		return actionDone, action, err
 	} else if actionDone {
 		glog.V(2).Infof("FixUntrustedNodes executed an action on the cluster (dryRun: %v)", dryRun)
-		return actionDone, nil
+		return actionDone, action, nil
 	}
 
 	// delete pods that are stuck in terminating state
+	action = FixTerminatingPodsAction
 	if actionDone, err = FixTerminatingPods(cluster, podControl, 1*time.Minute, dryRun); err != nil {
-		return actionDone, err
+		return actionDone, action, err
 	} else if actionDone {
 		glog.V(2).Infof("FixTerminatingPods executed an action on the cluster (dryRun: %v)", dryRun)
-		return actionDone, nil
+		return actionDone, action, nil
 	}
 
 	// detect and fix cluster split
+	action = FixClusterSplitAction
 	if actionDone, err = FixClusterSplit(ctx, admin, config, infos, dryRun); err != nil {
-		return actionDone, err
+		return actionDone, action, err
 	} else if actionDone {
 		glog.V(2).Infof("FixClusterSplit executed an action on the cluster (dryRun: %v)", dryRun)
-		return actionDone, nil
+		return actionDone, action, nil
 	}
 
-	return actionDone, err
+	// all checks cleared
+	action = NoAction
+
+	return actionDone, action, err
 }


### PR DESCRIPTION
In the current implementation, when pods are terminating, the terminating pod sanity check doesn't run because fix failed nodes check fails and the operator doesn't execute other checks. This PR will make sure to run the check.