### PR TITLE
Add missing appVersion to Chart.yaml for redis operator chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Package operator-for-redis chart
         env:
           OPERATOR_VERSION: ${{ needs.operator.outputs.version }}
-        run: helm package charts/operator-for-redis --version=$OPERATOR_VERSION --destination helm-releases
+        run: helm package charts/operator-for-redis --version=$OPERATOR_VERSION --app-version=$OPERATOR_VERSION --destination helm-releases
 
       - name: Package node-for-redis chart
         env:


### PR DESCRIPTION
### Problem

The current Helm chart for `operator-for-redis` does not specify an `appVersion` field in `Chart.yaml`.

Also `.Values.image.tag` is empty in `values.yaml`:

```yaml
image:
  repository: cinple/operator-for-redis-cluster-operator
  # Overrides the image tag whose default is the chart appVersion
  tag: ""
  pullPolicy: IfNotPresent
```

As a result, the image tag in `deployment.yaml` defaults to an empty value:

```yaml
image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
```

This leads to an invalid image reference causing deployment failures. 

```yaml
image: cinple/operator-for-redis-cluster-operator:
```

According to the [Helm documentation on the appVersion field](https://helm.sh/docs/topics/charts/#the-appversion-field), the `appVersion` is used to track the application version being packaged, and it serves as the default image tag if not overridden.

### Solution

Add the `--app-version=$OPERATOR_VERSION` flag to the helm package command to fix this.
This change ensures the chart's `appVersion` is populated, preventing empty image tags and deployment issues.