### PR TITLE
Stabilize PR e2e CI for combined scaling operations.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -165,7 +165,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
           config: ./test/e2e/kind_config.yml
           cluster_name: kind
-          node_image: ${{ matrix.kind-node }}
+          node_image: kindest/node:v${{ matrix.kubernetes-version }}
           wait: 120s
             
       - name: Load Images to KIND
@@ -181,7 +181,7 @@ jobs:
       
       - name: Run e2e tests
         id: e2e
-        run: go test -timeout 30m ./test/e2e --kubeconfig=$HOME/.kube/config --ginkgo.v --test.v
+        run: go test -timeout 45m ./test/e2e --kubeconfig=$HOME/.kube/config --ginkgo.v --test.v
 
       - name: Capture logs if e2e failed
         if: ${{ always() && (steps.e2e.outcome == 'failure' || steps.helm.outcome == 'failure') }}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -128,7 +128,7 @@ lazyfree-lazy-expire yes`,
 					replicas := int32(2)
 					gomega.Eventually(framework.UpdateConfigRedisClusterFunc(kubeClient, cluster, &nbPrimary, &replicas), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 
-					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "5m", "5s").ShouldNot(gomega.HaveOccurred())
+					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "8m", "5s").ShouldNot(gomega.HaveOccurred())
 
 					gomega.Eventually(framework.ZonesBalancedFunc(kubeClient, cluster), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 				})
@@ -139,7 +139,7 @@ lazyfree-lazy-expire yes`,
 					replicas := int32(1)
 					gomega.Eventually(framework.UpdateConfigRedisClusterFunc(kubeClient, cluster, &nbPrimary, &replicas), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 
-					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "5m", "5s").ShouldNot(gomega.HaveOccurred())
+					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "8m", "5s").ShouldNot(gomega.HaveOccurred())
 
 					gomega.Eventually(framework.ZonesBalancedFunc(kubeClient, cluster), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 				})
@@ -150,7 +150,7 @@ lazyfree-lazy-expire yes`,
 					replicas := int32(2)
 					gomega.Eventually(framework.UpdateConfigRedisClusterFunc(kubeClient, cluster, &nbPrimary, &replicas), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 
-					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "5m", "5s").ShouldNot(gomega.HaveOccurred())
+					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "8m", "5s").ShouldNot(gomega.HaveOccurred())
 
 					gomega.Eventually(framework.ZonesBalancedFunc(kubeClient, cluster), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 				})
@@ -161,7 +161,7 @@ lazyfree-lazy-expire yes`,
 					replicas := int32(1)
 					gomega.Eventually(framework.UpdateConfigRedisClusterFunc(kubeClient, cluster, &nbPrimary, &replicas), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 
-					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "5m", "5s").ShouldNot(gomega.HaveOccurred())
+					gomega.Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "8m", "5s").ShouldNot(gomega.HaveOccurred())
 
 					gomega.Eventually(framework.ZonesBalancedFunc(kubeClient, cluster), "5s", "1s").ShouldNot(gomega.HaveOccurred())
 				})


### PR DESCRIPTION
Fix kind node_image to use matrix kubernetes-version and give dual-dimension scale specs an 8m readiness window so slow GitHub runners do not flake at 5m.